### PR TITLE
feat:Add execution method via avatar right-click

### DIFF
--- a/Editor/AvatarMenuCreatorForMA.cs
+++ b/Editor/AvatarMenuCreatorForMA.cs
@@ -44,6 +44,19 @@ namespace net.narazaka.avatarmenucreator.editor
         {
             GetWindow<AvatarMenuCreatorForMA>("AvatarMenuCreator for Modular Avatar");
         }
+        
+        [MenuItem("GameObject/AvatarMenuCreator for Modular Avatar", validate = true)]
+        static bool CreateWindowfromGameObjectValidation()
+        {
+            return Selection.activeGameObject != null && Selection.activeGameObject.GetComponent<VRCAvatarDescriptor>() != null;
+        }
+
+        [MenuItem("GameObject/AvatarMenuCreator for Modular Avatar")]
+        static void CreateWindowfromGameObject()
+        {
+            var window = GetWindow<AvatarMenuCreatorForMA>("AvatarMenuCreator for Modular Avatar");
+            window.VRCAvatarDescriptor = Selection.activeGameObject.GetComponent<VRCAvatarDescriptor>();
+        }
 
         void OnEnable()
         {


### PR DESCRIPTION
このPRはヒエラルキー上からアバターを右クリックすることで実行する方法を追加するものです。Toolsから開く実行方法と比較しアバターをD&Dする手間が省けます。
アバタールートのみで表示するようにしたため、実行の可否が変わりやすいようにMenuItemの階層はModular Avatarを外し一段上へと上げました。Toolsと統一したい場合はそのように修正します。